### PR TITLE
feat: add NocoDB spreadsheet UI on CNPG PostgreSQL

### DIFF
--- a/k8s/argocd/applications/nocodb.yaml
+++ b/k8s/argocd/applications/nocodb.yaml
@@ -1,0 +1,93 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: nocodb
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://zekker6.github.io/helm-charts/
+    chart: nocodb
+    targetRevision: "1.10.0"
+    helm:
+      values: |
+        image:
+          repository: nocodb/nocodb
+          tag: "0.301.5"
+          pullPolicy: IfNotPresent
+
+        env:
+          TZ: "Europe/Berlin"
+
+          # ── Datenbank ────────────────────────────────────────────────────
+          # NC_DB URL kommt komplett aus dem Secret (inkl. Passwort).
+          # So gibt es keinen Interpolations-Mismatch zwischen Secret und URL.
+          # WICHTIG: setup-nocodb.sh erstellt db-url und db-password synchron.
+          NC_DB:
+            valueFrom:
+              secretKeyRef:
+                name: nocodb-secret
+                key: db-url
+
+          # ── Security ─────────────────────────────────────────────────────
+          NC_AUTH_JWT_SECRET:
+            valueFrom:
+              secretKeyRef:
+                name: nocodb-secret
+                key: jwt-secret
+
+          # ── Anwendungseinstellungen ───────────────────────────────────────
+          NC_PUBLIC_URL: "https://nocodb.homelab.local"
+
+          # Telemetrie deaktivieren
+          NC_DISABLE_TELE: "true"
+
+          # Signup nur für den ersten Admin-User erlauben
+          NC_INVITE_ONLY_SIGNUP: "false"
+
+          # Node.js Heap explizit setzen – verhindert OOM bei Startup
+          NODE_OPTIONS: "--max-old-space-size=768"
+
+        # ── Kein SQLite PVC nötig – wir nutzen PostgreSQL ─────────────────
+        persistence:
+          data:
+            enabled: false
+
+        service:
+          main:
+            ports:
+              http:
+                port: 8080
+
+        ingress:
+          main:
+            enabled: true
+            ingressClassName: traefik
+            hosts:
+              - host: nocodb.homelab.local
+                paths:
+                  - path: /
+                    pathType: Prefix
+            tls:
+              - secretName: homelab-wildcard-tls
+                hosts:
+                  - nocodb.homelab.local
+
+        resources:
+          requests:
+            memory: 512Mi
+            cpu: 100m
+          limits:
+            memory: 1Gi
+
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: productivity
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/scripts/setup-coredns.sh
+++ b/scripts/setup-coredns.sh
@@ -39,9 +39,6 @@ fi
 echo "    Traefik Cluster-IP: ${TRAEFIK_IP}"
 
 # ─── Step 2: Verify the default Corefile imports coredns-custom ──────────────
-# k3s CoreDNS Corefile contains: import /etc/coredns/custom/*.server
-# The coredns-custom ConfigMap is mounted at /etc/coredns/custom/ inside the
-# CoreDNS pod. Any *.server key in that ConfigMap is automatically loaded.
 echo ""
 echo "==> Verifying k3s CoreDNS supports coredns-custom..."
 if kubectl get configmap coredns -n kube-system \
@@ -56,11 +53,6 @@ fi
 FALLBACK=${FALLBACK:-false}
 
 # ─── Step 3: Apply coredns-custom ConfigMap ───────────────────────────────────
-# Each key in coredns-custom must end in .server to be picked up by CoreDNS.
-# We use 'homelab.server' as the key name.
-#
-# The wildcard hosts entry (*.homelab.local → Traefik IP) means any new service
-# automatically works without changing CoreDNS again.
 if [[ "${FALLBACK}" == "false" ]]; then
   echo ""
   echo "==> Applying coredns-custom ConfigMap (k3s-safe, survives restarts)..."
@@ -85,6 +77,7 @@ data:
             ${TRAEFIK_IP} homarr.homelab.local
             ${TRAEFIK_IP} vault.homelab.local
             ${TRAEFIK_IP} paperless.homelab.local
+            ${TRAEFIK_IP} nocodb.homelab.local
             ${TRAEFIK_IP} homelab.local
             fallthrough
         }
@@ -127,6 +120,7 @@ else
         ${TRAEFIK_IP} homarr.homelab.local
         ${TRAEFIK_IP} vault.homelab.local
         ${TRAEFIK_IP} paperless.homelab.local
+        ${TRAEFIK_IP} nocodb.homelab.local
         ${TRAEFIK_IP} homelab.local
         fallthrough
     }
@@ -163,8 +157,8 @@ kubectl run -it --rm dns-test --image=alpine --restart=Never -- \
     nslookup auth.homelab.local
     echo '--- gitlab.homelab.local ---'
     nslookup gitlab.homelab.local
-    echo '--- argocd.homelab.local ---'
-    nslookup argocd.homelab.local
+    echo '--- nocodb.homelab.local ---'
+    nslookup nocodb.homelab.local
   " 2>/dev/null || echo "    (DNS test pod cleanup complete)"
 
 # ─── Done ────────────────────────────────────────────────────────────────────
@@ -183,13 +177,14 @@ echo ""
 echo "  All *.homelab.local domains now resolve"
 echo "  inside the cluster → Traefik → Service"
 echo ""
-echo "  This means:"
-echo "  - GitLab → Keycloak OIDC works"
-echo "  - ArgoCD → Keycloak OIDC works"
-echo "  - Any new *.homelab.local service works"
-echo "    automatically without changing CoreDNS"
-echo ""
-echo "  Verify manually:"
-echo "    kubectl run -it --rm dns-test --image=alpine --restart=Never -- \\"
-echo "      nslookup auth.homelab.local"
+echo "  Services:"
+echo "    - auth.homelab.local       (Keycloak)"
+echo "    - gitlab.homelab.local     (GitLab)"
+echo "    - argocd.homelab.local     (ArgoCD)"
+echo "    - grafana.homelab.local    (Grafana)"
+echo "    - nextcloud.homelab.local  (Nextcloud)"
+echo "    - homarr.homelab.local     (Homarr)"
+echo "    - vault.homelab.local      (Vaultwarden)"
+echo "    - paperless.homelab.local  (Paperless-ngx)"
+echo "    - nocodb.homelab.local     (NocoDB)"
 echo "============================================"

--- a/scripts/setup-nocodb.sh
+++ b/scripts/setup-nocodb.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+set -euo pipefail
+
+# =============================================================================
+#  setup-nocodb.sh
+#  Richtet PostgreSQL-Datenbank und Kubernetes Secret für NocoDB ein.
+#
+#  VORAUSSETZUNGEN:
+#  - kubectl konfiguriert und Cluster erreichbar
+#  - PostgreSQL (CNPG) läuft: kubectl get cluster -n infrastructure
+#  - Namespace 'productivity' existiert
+#
+#  IDEMPOTENT: Erneutes Ausführen synct DB-Passwort und Secret zusammen.
+#
+#  USAGE:
+#    ./scripts/setup-nocodb.sh
+# =============================================================================
+
+NAMESPACE="productivity"
+SECRET_NAME="nocodb-secret"
+DB_HOST="homelab-pg-rw.infrastructure.svc.cluster.local"
+DB_PORT="5432"
+DB_NAME="nocodb"
+DB_USER="nocodb"
+
+echo ""
+echo "============================================"
+echo "  NocoDB – Datenbank & Secret Setup"
+echo "============================================"
+echo ""
+
+# ─── Voraussetzungen prüfen ───────────────────────────────────────────────────
+echo "==> Prüfe Voraussetzungen..."
+
+if ! kubectl get pod homelab-pg-1 -n infrastructure &>/dev/null; then
+  echo "    FEHLER: PostgreSQL Pod 'homelab-pg-1' nicht gefunden."
+  exit 1
+fi
+echo "    PostgreSQL: OK"
+
+kubectl get namespace "${NAMESPACE}" &>/dev/null || kubectl create namespace "${NAMESPACE}"
+echo "    Namespace '${NAMESPACE}': OK"
+
+# ─── Warten bis PostgreSQL bereit ist ────────────────────────────────────────
+echo ""
+echo "==> Warte bis PostgreSQL bereit ist..."
+kubectl wait --for=condition=Ready pod/homelab-pg-1 -n infrastructure --timeout=120s
+echo "    PostgreSQL bereit."
+
+# ─── Passwort generieren ─────────────────────────────────────────────────────
+echo ""
+echo "==> Generiere Credentials..."
+NOCODB_DB_PW=$(openssl rand -base64 24)
+NOCODB_JWT_SECRET=$(openssl rand -base64 48)
+
+# NC_DB URL komplett zusammenbauen – Passwort und URL werden synchron gespeichert.
+# Das verhindert den 28P01 Auth-Fehler durch URL/Secret-Mismatch.
+NOCODB_DB_URL="pg://${DB_HOST}:${DB_PORT}?u=${DB_USER}&p=${NOCODB_DB_PW}&d=${DB_NAME}"
+
+# ─── Datenbank und User anlegen / Passwort setzen ────────────────────────────
+echo ""
+echo "==> Lege PostgreSQL Datenbank und User an..."
+
+kubectl exec homelab-pg-1 -n infrastructure -c postgres -- psql -U postgres -c \
+  "CREATE DATABASE ${DB_NAME};" 2>/dev/null \
+  && echo "    Datenbank '${DB_NAME}' erstellt." \
+  || echo "    Datenbank '${DB_NAME}' existiert bereits."
+
+# ALTER ROLE setzt das Passwort auch wenn der User bereits existiert → idempotent
+kubectl exec homelab-pg-1 -n infrastructure -c postgres -- psql -U postgres -c "
+  DO \$\$ BEGIN
+    IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = '${DB_USER}') THEN
+      CREATE ROLE ${DB_USER} WITH LOGIN PASSWORD '${NOCODB_DB_PW}';
+      RAISE NOTICE 'User ${DB_USER} erstellt.';
+    ELSE
+      ALTER ROLE ${DB_USER} WITH PASSWORD '${NOCODB_DB_PW}';
+      RAISE NOTICE 'User ${DB_USER} existiert – Passwort aktualisiert.';
+    END IF;
+  END \$\$;
+  GRANT ALL PRIVILEGES ON DATABASE ${DB_NAME} TO ${DB_USER};
+  ALTER DATABASE ${DB_NAME} OWNER TO ${DB_USER};
+"
+echo "    Berechtigungen gesetzt."
+
+# ─── Kubernetes Secret anlegen (altes löschen für saubere Synchronisation) ───
+echo ""
+echo "==> Erstelle Kubernetes Secret '${SECRET_NAME}'..."
+
+if kubectl get secret "${SECRET_NAME}" -n "${NAMESPACE}" &>/dev/null; then
+  echo "    Secret existiert – wird neu erstellt (Passwort-Sync)..."
+  kubectl delete secret "${SECRET_NAME}" -n "${NAMESPACE}"
+fi
+
+kubectl create secret generic "${SECRET_NAME}" \
+  --from-literal=db-password="${NOCODB_DB_PW}" \
+  --from-literal=db-url="${NOCODB_DB_URL}" \
+  --from-literal=jwt-secret="${NOCODB_JWT_SECRET}" \
+  -n "${NAMESPACE}"
+
+echo "    Secret '${SECRET_NAME}' erstellt."
+echo "    Keys: db-password, db-url, jwt-secret"
+
+# ─── Zusammenfassung ──────────────────────────────────────────────────────────
+echo ""
+echo "============================================"
+echo "  Setup abgeschlossen!"
+echo ""
+echo "  PostgreSQL:"
+echo "    Datenbank: ${DB_NAME}"
+echo "    User:      ${DB_USER}"
+echo "    Passwort:  ${NOCODB_DB_PW}"
+echo "    → In Ansible Vault sichern: make vault-edit"
+echo ""
+echo "  Nächste Schritte:"
+echo ""
+echo "  1. Falls Pod läuft – neu starten damit neues Secret greift:"
+echo "     kubectl rollout restart deployment/nocodb -n ${NAMESPACE}"
+echo ""
+echo "  2. CoreDNS Eintrag setzen (falls noch nicht geschehen):"
+echo "     make setup-coredns"
+echo ""
+echo "  3. ArgoCD Application deployen:"
+echo "     git add k8s/argocd/applications/nocodb.yaml"
+echo "     git commit -m 'feat: add NocoDB spreadsheet UI'"
+echo "     git push"
+echo ""
+echo "  4. NocoDB aufrufen:"
+echo "     https://nocodb.homelab.local"
+echo "     → Beim ersten Aufruf Admin-Account anlegen"
+echo "============================================"


### PR DESCRIPTION
## feat: add NocoDB as spreadsheet UI on CNPG PostgreSQL

### Summary

Deploys NocoDB as an Airtable-like spreadsheet interface directly on top of the existing CNPG PostgreSQL cluster. No additional database required — NocoDB uses a dedicated `nocodb` database on `homelab-pg`.

### Changes

- `k8s/argocd/applications/nocodb.yaml` — ArgoCD Application (zekker6/nocodb Chart 1.10.0, NocoDB 0.301.5)
- `scripts/setup-nocodb.sh` — PostgreSQL DB + User + Kubernetes Secret setup
- `scripts/setup-coredns.sh` — Added `nocodb.homelab.local` to CoreDNS

### Architecture

```
https://nocodb.homelab.local
  → Traefik (wildcard TLS)
    → NocoDB Pod (namespace: productivity)
      → homelab-pg-rw.infrastructure (CNPG PostgreSQL)
```

### Technical Notes

- **DB connection**: Full `NC_DB` URL stored as a single secret key (`db-url`) to avoid password/URL sync issues with Helm value interpolation
- **Memory**: `NODE_OPTIONS=--max-old-space-size=768` + 1Gi container limit to prevent Node.js OOM on startup
- **No OIDC**: NocoDB SSO requires Enterprise Edition — first admin account is created on first visit at `https://nocodb.homelab.local`
- **Telemetry**: Disabled via `NC_DISABLE_TELE=true`

### Deployment

```bash
# One-time setup
./scripts/setup-nocodb.sh
make setup-coredns

# Verify
kubectl get pods -n productivity | grep nocodb
```

### Relates to

Closes #34 