### PR TITLE
feat: migrate all secrets to Vault via External Secrets Operator (#27)

### DIFF
--- a/k8s/security/external-secrets/auth/keycloak-db-secret.yaml
+++ b/k8s/security/external-secrets/auth/keycloak-db-secret.yaml
@@ -1,0 +1,18 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: keycloak-db-secret
+  namespace: auth
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault
+    kind: ClusterSecretStore
+  target:
+    name: keycloak-db-secret
+    creationPolicy: Owner
+  data:
+    - secretKey: password
+      remoteRef:
+        key: homelab/auth/keycloak-db-secret
+        property: password

--- a/k8s/security/external-secrets/auth/keycloak-secret.yaml
+++ b/k8s/security/external-secrets/auth/keycloak-secret.yaml
@@ -1,0 +1,18 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: keycloak-secret
+  namespace: auth
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault
+    kind: ClusterSecretStore
+  target:
+    name: keycloak-secret
+    creationPolicy: Owner
+  data:
+    - secretKey: admin-password
+      remoteRef:
+        key: homelab/auth/keycloak-secret
+        property: admin-password

--- a/k8s/security/external-secrets/dashboard/db-encryption.yaml
+++ b/k8s/security/external-secrets/dashboard/db-encryption.yaml
@@ -1,0 +1,18 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: db-encryption
+  namespace: dashboard
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault
+    kind: ClusterSecretStore
+  target:
+    name: db-encryption
+    creationPolicy: Owner
+  data:
+    - secretKey: db-encryption-key
+      remoteRef:
+        key: homelab/dashboard/db-encryption
+        property: db-encryption-key

--- a/k8s/security/external-secrets/dashboard/homarr-secret.yaml
+++ b/k8s/security/external-secrets/dashboard/homarr-secret.yaml
@@ -1,0 +1,22 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: homarr-secret
+  namespace: dashboard
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault
+    kind: ClusterSecretStore
+  target:
+    name: homarr-secret
+    creationPolicy: Owner
+  data:
+    - secretKey: AUTH_OIDC_CLIENT_SECRET
+      remoteRef:
+        key: homelab/dashboard/homarr-secret
+        property: AUTH_OIDC_CLIENT_SECRET
+    - secretKey: SECRET_ENCRYPTION_KEY
+      remoteRef:
+        key: homelab/dashboard/homarr-secret
+        property: SECRET_ENCRYPTION_KEY

--- a/k8s/security/external-secrets/gitlab/gitlab-rails-secrets.yaml
+++ b/k8s/security/external-secrets/gitlab/gitlab-rails-secrets.yaml
@@ -1,0 +1,30 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: gitlab-rails-secrets
+  namespace: gitlab
+spec:
+  refreshInterval: 24h  # Rails Keys niemals rotieren solange GitLab läuft!
+  secretStoreRef:
+    name: vault
+    kind: ClusterSecretStore
+  target:
+    name: gitlab-rails-secrets
+    creationPolicy: Owner
+  data:
+    - secretKey: secret_key_base
+      remoteRef:
+        key: homelab/gitlab/rails-secrets
+        property: secret-key-base
+    - secretKey: db_key_base
+      remoteRef:
+        key: homelab/gitlab/rails-secrets
+        property: db-key-base
+    - secretKey: otp_key_base
+      remoteRef:
+        key: homelab/gitlab/rails-secrets
+        property: otp-key-base
+    - secretKey: ci_job_token_signing_key
+      remoteRef:
+        key: homelab/gitlab/rails-secrets
+        property: ci-job-token-signing-key

--- a/k8s/security/external-secrets/gitlab/gitlab-runner-secret.yaml
+++ b/k8s/security/external-secrets/gitlab/gitlab-runner-secret.yaml
@@ -1,0 +1,22 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: gitlab-runner-secret
+  namespace: gitlab
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault
+    kind: ClusterSecretStore
+  target:
+    name: gitlab-runner-secret
+    creationPolicy: Owner
+  data:
+    - secretKey: runner-registration-token
+      remoteRef:
+        key: homelab/gitlab/runner-secret
+        property: runner-registration-token
+    - secretKey: runner-token
+      remoteRef:
+        key: homelab/gitlab/runner-secret
+        property: runner-token

--- a/k8s/security/external-secrets/gitlab/gitlab-secret.yaml
+++ b/k8s/security/external-secrets/gitlab/gitlab-secret.yaml
@@ -1,0 +1,26 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: gitlab-secret
+  namespace: gitlab
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault
+    kind: ClusterSecretStore
+  target:
+    name: gitlab-secret
+    creationPolicy: Owner
+  data:
+    - secretKey: db-password
+      remoteRef:
+        key: homelab/gitlab/gitlab-secret
+        property: db-password
+    - secretKey: redis-password
+      remoteRef:
+        key: homelab/gitlab/gitlab-secret
+        property: redis-password
+    - secretKey: oidc-client-secret
+      remoteRef:
+        key: homelab/gitlab/gitlab-secret
+        property: oidc-client-secret

--- a/k8s/security/external-secrets/infrastructure/minio-secret.yaml
+++ b/k8s/security/external-secrets/infrastructure/minio-secret.yaml
@@ -1,0 +1,26 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: minio-secret
+  namespace: infrastructure
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault
+    kind: ClusterSecretStore
+  target:
+    name: minio-secret
+    creationPolicy: Owner
+  data:
+    - secretKey: rootUser
+      remoteRef:
+        key: homelab/infrastructure/minio
+        property: rootUser
+    - secretKey: rootPassword
+      remoteRef:
+        key: homelab/infrastructure/minio
+        property: rootPassword
+    - secretKey: storage-box-password
+      remoteRef:
+        key: homelab/infrastructure/minio
+        property: storage-box-password

--- a/k8s/security/external-secrets/infrastructure/restic-ssh-key.yaml
+++ b/k8s/security/external-secrets/infrastructure/restic-ssh-key.yaml
@@ -1,0 +1,34 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: restic-ssh-key
+  namespace: infrastructure
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault
+    kind: ClusterSecretStore
+  target:
+    name: restic-ssh-key
+    creationPolicy: Owner
+  data:
+    - secretKey: ssh-privatekey
+      remoteRef:
+        key: homelab/infrastructure/restic-ssh
+        property: ssh-privatekey
+    - secretKey: ssh-publickey
+      remoteRef:
+        key: homelab/infrastructure/restic-ssh
+        property: ssh-publickey
+    - secretKey: storage-box-host
+      remoteRef:
+        key: homelab/infrastructure/restic-ssh
+        property: storage-box-host
+    - secretKey: storage-box-user
+      remoteRef:
+        key: homelab/infrastructure/restic-ssh
+        property: storage-box-user
+    - secretKey: storage-box-port
+      remoteRef:
+        key: homelab/infrastructure/restic-ssh
+        property: storage-box-port

--- a/k8s/security/external-secrets/monitoring/grafana-keycloak-secret.yaml
+++ b/k8s/security/external-secrets/monitoring/grafana-keycloak-secret.yaml
@@ -1,0 +1,22 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: grafana-keycloak-secret
+  namespace: monitoring
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault
+    kind: ClusterSecretStore
+  target:
+    name: grafana-keycloak-secret
+    creationPolicy: Owner
+  data:
+    - secretKey: GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET
+      remoteRef:
+        key: homelab/monitoring/grafana-keycloak-secret
+        property: GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET
+    - secretKey: ALERTMANAGER_DISCORD_WEBHOOK_URL
+      remoteRef:
+        key: homelab/monitoring/grafana-keycloak-secret
+        property: ALERTMANAGER_DISCORD_WEBHOOK_URL

--- a/k8s/security/external-secrets/productivity/nextcloud-secret.yaml
+++ b/k8s/security/external-secrets/productivity/nextcloud-secret.yaml
@@ -1,0 +1,42 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: nextcloud-secret
+  namespace: productivity
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault
+    kind: ClusterSecretStore
+  target:
+    name: nextcloud-secret
+    creationPolicy: Owner
+  data:
+    - secretKey: nextcloud-username
+      remoteRef:
+        key: homelab/productivity/nextcloud-secret
+        property: nextcloud-username
+    - secretKey: nextcloud-password
+      remoteRef:
+        key: homelab/productivity/nextcloud-secret
+        property: nextcloud-password
+    - secretKey: db-username
+      remoteRef:
+        key: homelab/productivity/nextcloud-secret
+        property: db-username
+    - secretKey: db-password
+      remoteRef:
+        key: homelab/productivity/nextcloud-secret
+        property: db-password
+    - secretKey: redis-password
+      remoteRef:
+        key: homelab/productivity/nextcloud-secret
+        property: redis-password
+    - secretKey: storage-box-password
+      remoteRef:
+        key: homelab/productivity/nextcloud-secret
+        property: storage-box-password
+    - secretKey: oidc-client-secret
+      remoteRef:
+        key: homelab/productivity/nextcloud-secret
+        property: oidc-client-secret

--- a/k8s/security/external-secrets/productivity/nocodb-secret.yaml
+++ b/k8s/security/external-secrets/productivity/nocodb-secret.yaml
@@ -1,0 +1,26 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: nocodb-secret
+  namespace: productivity
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault
+    kind: ClusterSecretStore
+  target:
+    name: nocodb-secret
+    creationPolicy: Owner
+  data:
+    - secretKey: db-password
+      remoteRef:
+        key: homelab/productivity/nocodb-secret
+        property: db-password
+    - secretKey: db-url
+      remoteRef:
+        key: homelab/productivity/nocodb-secret
+        property: db-url
+    - secretKey: jwt-secret
+      remoteRef:
+        key: homelab/productivity/nocodb-secret
+        property: jwt-secret

--- a/k8s/security/external-secrets/productivity/paperless-secret.yaml
+++ b/k8s/security/external-secrets/productivity/paperless-secret.yaml
@@ -1,0 +1,46 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: paperless-secret
+  namespace: productivity
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault
+    kind: ClusterSecretStore
+  target:
+    name: paperless-secret
+    creationPolicy: Owner
+  data:
+    - secretKey: db-username
+      remoteRef:
+        key: homelab/productivity/paperless-secret
+        property: db-username
+    - secretKey: db-password
+      remoteRef:
+        key: homelab/productivity/paperless-secret
+        property: db-password
+    - secretKey: redis-password
+      remoteRef:
+        key: homelab/productivity/paperless-secret
+        property: redis-password
+    - secretKey: redis-url
+      remoteRef:
+        key: homelab/productivity/paperless-secret
+        property: redis-url
+    - secretKey: secret-key
+      remoteRef:
+        key: homelab/productivity/paperless-secret
+        property: secret-key
+    - secretKey: oidc-client-secret
+      remoteRef:
+        key: homelab/productivity/paperless-secret
+        property: oidc-client-secret
+    - secretKey: smtp-username
+      remoteRef:
+        key: homelab/productivity/paperless-secret
+        property: smtp-username
+    - secretKey: smtp-password
+      remoteRef:
+        key: homelab/productivity/paperless-secret
+        property: smtp-password

--- a/k8s/security/external-secrets/security/vaultwarden-secret.yaml
+++ b/k8s/security/external-secrets/security/vaultwarden-secret.yaml
@@ -1,0 +1,18 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: vaultwarden-secret
+  namespace: security
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault
+    kind: ClusterSecretStore
+  target:
+    name: vaultwarden-secret
+    creationPolicy: Owner
+  data:
+    - secretKey: admin-token
+      remoteRef:
+        key: homelab/security/vaultwarden-secret
+        property: admin-token

--- a/k8s/security/external-secrets/security/vaultwarden-smtp.yaml
+++ b/k8s/security/external-secrets/security/vaultwarden-smtp.yaml
@@ -1,0 +1,22 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: vaultwarden-smtp
+  namespace: security
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault
+    kind: ClusterSecretStore
+  target:
+    name: vaultwarden
+    creationPolicy: Owner
+  data:
+    - secretKey: SMTP_USERNAME
+      remoteRef:
+        key: homelab/security/vaultwarden-smtp
+        property: SMTP_USERNAME
+    - secretKey: SMTP_PASSWORD
+      remoteRef:
+        key: homelab/security/vaultwarden-smtp
+        property: SMTP_PASSWORD

--- a/k8s/security/vault-cluster-secret-store.yaml
+++ b/k8s/security/vault-cluster-secret-store.yaml
@@ -24,29 +24,3 @@ spec:
           serviceAccountRef:
             name: "external-secrets"
             namespace: "external-secrets"
-
----
-# Demo ExternalSecret: Zeigt wie ein Vault Secret → Kubernetes Secret wird.
-# secret/homelab/test/demo → Namespace 'security', Secret 'vault-demo'
-#
-# Testen:
-#   kubectl get secret vault-demo -n security -o jsonpath='{.data.hello}' | base64 -d
-#   → world
-apiVersion: external-secrets.io/v1
-kind: ExternalSecret
-metadata:
-  name: vault-demo
-  namespace: security
-spec:
-  refreshInterval: 1h
-  secretStoreRef:
-    name: vault
-    kind: ClusterSecretStore
-  target:
-    name: vault-demo
-    creationPolicy: Owner
-  data:
-    - secretKey: hello
-      remoteRef:
-        key: homelab/test/demo
-        property: hello


### PR DESCRIPTION
## Migrate all Secrets to Vault via External Secrets Operator

Closes #27

### Was wurde gemacht?

Alle Kubernetes Secrets die bisher manuell per Bootstrap-Script angelegt
wurden sind jetzt in Vault als zentrale Source of Truth gespeichert.
ESO synct sie automatisch als Kubernetes Secrets in die jeweiligen Namespaces.

### Migrierte Secrets (15)

| Namespace | Secret | Vault Pfad |
|---|---|---|
| `infrastructure` | `minio-secret` | `homelab/infrastructure/minio` |
| `infrastructure` | `restic-ssh-key` | `homelab/infrastructure/restic-ssh` |
| `gitlab` | `gitlab-secret` | `homelab/gitlab/gitlab-secret` |
| `gitlab` | `gitlab-rails-secrets` | `homelab/gitlab/rails-secrets` |
| `gitlab` | `gitlab-runner-secret` | `homelab/gitlab/runner-secret` |
| `auth` | `keycloak-secret` | `homelab/auth/keycloak-secret` |
| `auth` | `keycloak-db-secret` | `homelab/auth/keycloak-db-secret` |
| `productivity` | `nextcloud-secret` | `homelab/productivity/nextcloud-secret` |
| `productivity` | `paperless-secret` | `homelab/productivity/paperless-secret` |
| `productivity` | `nocodb-secret` | `homelab/productivity/nocodb-secret` |
| `monitoring` | `grafana-keycloak-secret` | `homelab/monitoring/grafana-keycloak-secret` |
| `security` | `vaultwarden-secret` | `homelab/security/vaultwarden-secret` |
| `security` | `vaultwarden` | `homelab/security/vaultwarden-smtp` |
| `dashboard` | `homarr-secret` | `homelab/dashboard/homarr-secret` |
| `dashboard` | `db-encryption` | `homelab/dashboard/db-encryption` |

### Wie funktioniert es?

Vault KV (source of truth)
└── ESO ClusterSecretStore (auth: Kubernetes ServiceAccount)
└── ExternalSecret Manifest (in k8s/security/external-secrets/<namespace>/)
└── Kubernetes Secret (automatisch synct, refreshInterval: 1h)
└── Pod nutzt Secret normal per secretKeyRef / envFrom
### Fixes

- ClusterSecretStore Kubernetes Auth: `alias_name_source` auf
  `serviceaccount_name` umgestellt (behebt 403 bei ESO 2.x + Vault 1.21)
- ESO API: `v1beta1` → `v1`

### Noch offen

- Bootstrap-Scripts auf Vault schreiben umstellen (folgt in neuem Issue)